### PR TITLE
DT113 - Return commission status as past tense (and more in the description)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "dt113",
+  "name": "the-lamby-shop",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "dt101",
+  "name": "dt113",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -7095,6 +7095,23 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/asn1.js": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/asn1.js/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
       "license": "MIT"
     },
     "node_modules/ast-types-flow": {

--- a/src/components/CommissionsSection.jsx
+++ b/src/components/CommissionsSection.jsx
@@ -335,7 +335,11 @@ function CommissionItem({
             onClick={toggleDropdown}
           >
             <div className="flex w-1/4">Id: {id}</div>
-            <div className="flex w-1/2">Client Name: {clientName}</div>
+            {/* 
+              We test if clientName length is 1 for null because 
+              of the space that always gets pushed into clientName
+            */}
+            <div className="flex w-1/2">Client Name: {clientName.length !== 1 ? clientName : "N/A"}</div>
             <div className="flex w-1/4">Date: {formattedDate(createdAt)}</div>
             <div className="flex w-1/4">Current status: {status}</div>
           </div>


### PR DESCRIPTION
_- Each commission item displays the id, client name, date, and current status on the card while the phone number and email can be found on the drop down when clicking on each card_
_- Date is formatted on the card as "month day, year"_
_- Item information displays N/A if the information is missing_
![image](https://github.com/user-attachments/assets/a4fb8c17-f1e7-402f-ab59-7cf4821c62da)

_- Statuses get returned in past tense (both admin and user view shown)_
![image](https://github.com/user-attachments/assets/4f844ee6-deb7-4255-a544-f43a36016213)
![image](https://github.com/user-attachments/assets/fc2bc549-5dea-41de-a572-eb47af753334)

_- Updated popup confirmation for updating commission statuses and deleting commissions_
![image](https://github.com/user-attachments/assets/100f220e-53e5-42e6-9224-eee1ac99d666)
![image](https://github.com/user-attachments/assets/404bfa99-6aff-42fc-a166-6bfcb4b7354d)

_-Items now get re-rendered without reloading page after deleting commissions and changing statuses_
