### PR TITLE
Admin commissionsection fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23355,6 +23355,102 @@
         "url": "https://github.com/sponsors/gregberge"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
+      "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@testing-library/dom/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@testing-library/jest-dom": {
       "version": "5.17.0",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.17.0.tgz",

--- a/src/App.js
+++ b/src/App.js
@@ -158,8 +158,9 @@ function App() {
                 <Route path="/" element={<HeroSection />} />
                 <Route path="/about" element={<AboutSection />} />
                 <Route path="/shop" element={<ShopSection />} />
+                {/* Fix added to commission section: added email and username props as they were removed */}
                 <Route path="/commissions" element={
-                  <CommissionsSection userRole={userRole} />} />
+                  <CommissionsSection userRole={userRole} email={email} username={username} />} />
                 <Route path="/contact" element={<ContactSection />} />
 
                 <Route path="/accountrecovery" element={<AccountRecovery />} />

--- a/src/components/CommissionsSection/AdminCommissionItems.jsx
+++ b/src/components/CommissionsSection/AdminCommissionItems.jsx
@@ -15,6 +15,8 @@ export default function AdminCommissionItem({
     setItems,
     setFormData,
     reloadData,
+    handleCheckBox,
+    setHandleCheckBox,
   }) {
     // For invoking popup messages
     const showToast = useToast();
@@ -27,7 +29,20 @@ export default function AdminCommissionItem({
   
     // For handling checkbox values
     const [selected, setSelected] = useState(null);
-  
+
+    /* 
+      FIX ADDED: 
+      When handleCheckBox gets turned true from AdminCommissionSection...
+        set selected variable to null, set handleCheckbox flag back to false, and clear items array
+    */
+    useEffect(() => {
+      if(handleCheckBox){
+        setSelected(null);
+        setHandleCheckBox(false);
+        setItems([null]);
+      }
+    }, [handleCheckBox])
+
     /*  
       Get's the id and sets the selected 
       commission status, pushing it into the
@@ -62,7 +77,7 @@ export default function AdminCommissionItem({
       const formattedDate = dateCreated.toLocaleDateString("en-US", options);
       return formattedDate;
     };
-  
+
     const confirmAction = () => {
       showToast(
         <>
@@ -93,6 +108,12 @@ export default function AdminCommissionItem({
         .then(response => {
           showToast(`Deleting commission ID ${id}`, "success");
           console.log(response.data);
+          /* 
+            FIX ADDED: 
+            To prevent other commission items from being opened 
+            when a deletion of another commission occurs
+          */
+          setIsOpen(false);
           // Reload data on successful delete
           reloadData();
         })

--- a/src/components/CommissionsSection/AdminCommissionItems.jsx
+++ b/src/components/CommissionsSection/AdminCommissionItems.jsx
@@ -39,7 +39,6 @@ export default function AdminCommissionItem({
       if(handleCheckBox){
         setSelected(null);
         setHandleCheckBox(false);
-        setItems([null]);
       }
     }, [handleCheckBox])
 

--- a/src/components/CommissionsSection/AdminCommissionSection.jsx
+++ b/src/components/CommissionsSection/AdminCommissionSection.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 import { useToast } from "../../contexts/ToastContext";
 import star from '../../images/story_stars_1.png';
+import { useNavigate } from 'react-router-dom';
 
 import AdminCommissionItem from './AdminCommissionItems';
 
@@ -94,7 +95,13 @@ export default function AdminCommissionSection() {
         "error"
       );
     };
-  
+
+    /* 
+      FIX ADDED: 
+      So checkboxes get unselected on completion of the confirm changes function.
+    */
+    const [handleCheckBox, setHandleCheckBox] = useState(false);
+
     // Update commission statuses if confirm chosen from confirmAction()
     const handleConfirm = async () => {
       let updatecommission_url = `https://cbothh6c5c.execute-api.us-west-2.amazonaws.com/Development/updateCommissionStatus`;
@@ -122,6 +129,8 @@ export default function AdminCommissionSection() {
                       successful update request
                     */         
                     loadAdminCommissions();
+                    // Invokes handleCheckbox function inside AdminCommissionItems
+                    setHandleCheckBox(true);
                 })
                 .catch(error => {
                     showToast(`Error updating status for commission ID ${items[i].id}`, "error");
@@ -174,6 +183,8 @@ export default function AdminCommissionSection() {
                   setItems={setItems}
                   setFormData={setFormData}
                   reloadData={loadAdminCommissions}
+                  handleCheckBox={handleCheckBox}
+                  setHandleCheckBox={setHandleCheckBox}
                 />
               </>
             ))}

--- a/src/components/CommissionsSection/AdminCommissionSection.jsx
+++ b/src/components/CommissionsSection/AdminCommissionSection.jsx
@@ -131,6 +131,7 @@ export default function AdminCommissionSection() {
                     loadAdminCommissions();
                     // Invokes handleCheckbox function inside AdminCommissionItems
                     setHandleCheckBox(true);
+                    setItems([{ id: null, commissionStatus: "" }]);
                 })
                 .catch(error => {
                     showToast(`Error updating status for commission ID ${items[i].id}`, "error");

--- a/src/components/CommissionsSection/UserCommissionsSection.jsx
+++ b/src/components/CommissionsSection/UserCommissionsSection.jsx
@@ -6,7 +6,7 @@ import star from '../../images/story_stars_1.png';
 import UsersPersonalCommissionItem from './UserPersonalCommissionItem';
 
 
-export default function UserCommisionsSection({userEmail}) {
+export default function UserCommisionsSection({userEmail, username}) {
     const [firstName, setFirstName] = useState("");
     const [lastName, setLastName] = useState("");
     //const [email, setEmail] = useState("");
@@ -85,14 +85,19 @@ export default function UserCommisionsSection({userEmail}) {
     }, []);
   
     const handleSubmit = async () => {
-      let email = userEmail;
       const commissionData = {
         firstName,
         lastName,
-        email,
+        email: userEmail,
         phoneNumber,
         description,
       };
+
+      // Fix added: prevent commission submission if no description is added
+      if(description === ""){
+        showToast("Description for commission needed! Nothing sent.", "error");
+        return;
+      }
   
       try {
         const response = await axios.post(
@@ -107,6 +112,7 @@ export default function UserCommisionsSection({userEmail}) {
         console.log("Success:", response.data);
         if (response.status === 200) {
           showToast("Commission Sent!", "success");
+          clearForm(); // Fix added: to clear form after every commission submission
           grabOwnCommissions();
         } else { 
           showToast("You pressed cancel, commission not sent!", "error"); 


### PR DESCRIPTION
- Readded the props for CommissionSection under App.js b/c they were somehow removed. This fixed the API call error that was being experienced. 
- Fixed admin view commission section workflow:
  - Fixed when a commission gets deleted, other commission items don't get opened anymore.
  - Fixed checkboxes not getting unselected after "confirm changes" button clicked and completed
  - Fixed error with how items are sent for status updates